### PR TITLE
copied health endpoint from default.pm for readiness check

### DIFF
--- a/lib/inventory.pm
+++ b/lib/inventory.pm
@@ -76,4 +76,14 @@ post '/' => sub {
    template index => {data => $data, timestamp => $timestamp};
 };
 
+get '/health' => sub {
+  my $dbh = get_connection();
+
+  if (not $dbh->ping) {
+    status 'error';
+    return "ERROR: Database did not respond to ping.";
+  }
+  return "SUCCESS: Database connection appears healthy.";
+};
+
 true;


### PR DESCRIPTION
Enabling the mysql example fails the deployment stage because there is no /health endpoint for the readiness check. I've copied the health endpoint from default.pm and added it to inventory.pm. 
