### PR TITLE
Expand health checks for 0E0 case

### DIFF
--- a/lib/default.pm
+++ b/lib/default.pm
@@ -46,9 +46,15 @@ get '/' => sub {
 };
 
 get '/health' => sub {
-  my $dbh = get_connection();
+  my $dbh  = get_connection();
+  my $ping = $dbh->ping
 
-  if (not $dbh->ping) {
+  if ($ping and $ping == 0) {
+    # This is the 'true but zero' case, meaning that ping() is not implemented for this DB type.
+    # See: http://search.cpan.org/~timb/DBI-1.636/DBI.pm#ping
+    return "WARNING: Database health uncertain; this database type does not support ping checks.";
+  }
+  elsif (not $ping) {
     status 'error';
     return "ERROR: Database did not respond to ping.";
   }

--- a/lib/inventory.pm
+++ b/lib/inventory.pm
@@ -77,9 +77,15 @@ post '/' => sub {
 };
 
 get '/health' => sub {
-  my $dbh = get_connection();
+  my $dbh  = get_connection();
+  my $ping = $dbh->ping
 
-  if (not $dbh->ping) {
+  if ($ping and $ping == 0) {
+    # This is the 'true but zero' case, meaning that ping() is not implemented for this DB type.
+    # See: http://search.cpan.org/~timb/DBI-1.636/DBI.pm#ping
+    return "WARNING: Database health uncertain; this database type does not support ping checks.";
+  }
+  elsif (not $ping) {
     status 'error';
     return "ERROR: Database did not respond to ping.";
   }


### PR DESCRIPTION
Per the DBI docs[^1](http://search.cpan.org/~timb/DBI-1.636/DBI.pm#ping), `ping()` has a default response of "zero-but-true". This enables a test of `$dbh->ping()` to pass even for database modules that do not actually implement a `ping()` method, in a way that differentiates them from true passing results.

This change to the health test accounts for this subtlety so that developers can be made aware of the potential for a misleading passing result in the zero-but-true instance.

@bparees or @mfojtik please review.
