### PR TITLE
Change DC strategy from Rolling to Recreate for DB templates

### DIFF
--- a/openshift/templates/dancer-mysql-persistent.json
+++ b/openshift/templates/dancer-mysql-persistent.json
@@ -147,6 +147,9 @@
         }
       },
       "spec": {
+        "strategy": {
+          "type": "Recreate"
+        },
         "triggers": [
           {
             "type": "ImageChange",

--- a/openshift/templates/dancer-mysql.json
+++ b/openshift/templates/dancer-mysql.json
@@ -147,6 +147,9 @@
         }
       },
       "spec": {
+        "strategy": {
+          "type": "Recreate"
+        },
         "triggers": [
           {
             "type": "ImageChange",


### PR DESCRIPTION
Dancer templates don't explicitly set the deployment strategy. Therefore,
it will be "Rolling" by default. However, Recreate strategy will allow
the redeployment process to stay within 1Gi memory limit instead of
requiring more memory due to extra pod is created for Rolling strategy.

Signed-off-by: Vu Dinh <vdinh@redhat.com>