### PR TITLE
use a non-broken version of http:xscookies

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
-requires "Dancer2" => "0.160001";
+requires "HTTP::XSCookies" , '< 0.000017';
+requires "Dancer2" => "0";
 requires "Dancer2::Plugin::Database" => "0";
-requires "DBD::mysql" => "4.031";
+requires "DBD::mysql" => "0";
 requires "YAML::XS" => "0";
 requires "Template" => "0";
 


### PR DESCRIPTION
revert this in the future when http:xscookies releases something newer
than 0.000017 that is not broken.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1553333
