### PR TITLE
Revert "use a non-broken version of http:xscookies"

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,6 @@
-requires "HTTP::XSCookies" , '< 0.000017';
-requires "Dancer2" => "0";
+requires "Dancer2" => "0.160001";
 requires "Dancer2::Plugin::Database" => "0";
-requires "DBD::mysql" => "0";
+requires "DBD::mysql" => "4.031";
 requires "YAML::XS" => "0";
 requires "Template" => "0";
 


### PR DESCRIPTION
This reverts commit 83e9a068ac3c1b28a2f9503bc88ae01d650d2c42.

A new release(0.000018) of http:xscookies has been created that fixes this, so we no longer need to lock to < 0.000017
