### PR TITLE
openshift/templates/dancer-mysql: use mysql 8.0

### DIFF
--- a/openshift/templates/dancer-mysql-persistent.json
+++ b/openshift/templates/dancer-mysql-persistent.json
@@ -325,7 +325,7 @@
               "from": {
                 "kind": "ImageStreamTag",
                 "namespace": "${NAMESPACE}",
-                "name": "mysql:5.7"
+                "name": "mysql:8.0"
               }
             }
           },

--- a/openshift/templates/dancer-mysql.json
+++ b/openshift/templates/dancer-mysql.json
@@ -308,7 +308,7 @@
               "from": {
                 "kind": "ImageStreamTag",
                 "namespace": "${NAMESPACE}",
-                "name": "mysql:5.7"
+                "name": "mysql:8.0"
               }
             }
           },


### PR DESCRIPTION
MySQL 5.7 has been deprecated in SCL