### PR TITLE
Update templates to 5.30

### DIFF
--- a/openshift/templates/dancer-mysql-persistent.json
+++ b/openshift/templates/dancer-mysql-persistent.json
@@ -440,9 +440,9 @@
     {
       "name": "PERL_VERSION",
       "displayName": "Version of Perl Image",
-      "description": "Version of Perl image to be used (5.26-el7, 5.26-ubi8, or latest).",
+      "description": "Version of Perl image to be used (5.30-el7, 5.30-ubi8, or latest).",
       "required": true,
-      "value": "5.26-ubi8"
+      "value": "5.30-ubi8"
     },
     {
       "name": "MEMORY_LIMIT",

--- a/openshift/templates/dancer-mysql.json
+++ b/openshift/templates/dancer-mysql.json
@@ -421,9 +421,9 @@
     {
       "name": "PERL_VERSION",
       "displayName": "Version of Perl Image",
-      "description": "Version of Perl image to be used (5.26-el7, 5.26-ubi8, or latest).",
+      "description": "Version of Perl image to be used (5.30-el7, 5.30-ubi8, or latest).",
       "required": true,
-      "value": "5.26-ubi8"
+      "value": "5.30-ubi8"
     },
     {
       "name": "MEMORY_LIMIT",

--- a/openshift/templates/dancer.json
+++ b/openshift/templates/dancer.json
@@ -232,9 +232,9 @@
     {
       "name": "PERL_VERSION",
       "displayName": "Version of Perl Image",
-      "description": "Version of Perl image to be used (5.26-el7, 5.26-ubi8, or latest).",
+      "description": "Version of Perl image to be used (5.30-el7, 5.30-ubi8, or latest).",
       "required": true,
-      "value": "5.26-ubi8"
+      "value": "5.30-ubi8"
     },
     {
       "name": "MEMORY_LIMIT",


### PR DESCRIPTION
Perl 5.26 is no longer supported.  This is a prerequisite of https://github.com/sclorg/s2i-perl-container/pull/207﻿
