### PR TITLE
Switch DBD::mysql to DBD::MariaDB.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires "Dancer2" => "0.160001";
 requires "Dancer2::Plugin::Database" => "0";
-requires 'DBD::mysql', '>= 4.050';
+requires 'DBD::MariaDB' => '0';
 requires "YAML::XS" => "0";
 requires "Template" => "0";
 

--- a/lib/default.pm
+++ b/lib/default.pm
@@ -2,7 +2,7 @@ package default;
 use Dancer2 ':syntax';
 use Template;
 use DBI;
-use DBD::mysql;
+use DBD::MariaDB;
 
 set template => 'template_toolkit';
 set layout => undef;
@@ -12,7 +12,7 @@ sub get_connection{
   my $service_name=uc $ENV{'DATABASE_SERVICE_NAME'};
   my $db_host=$ENV{"${service_name}_SERVICE_HOST"};
   my $db_port=$ENV{"${service_name}_SERVICE_PORT"};
-  my $dbh=DBI->connect("DBI:mysql:database=$ENV{'MYSQL_DATABASE'};host=$db_host;port=$db_port",$ENV{'MYSQL_USER'},$ENV{'MYSQL_PASSWORD'}) or return 0;
+  my $dbh=DBI->connect("DBI:MariaDB:database=$ENV{'MYSQL_DATABASE'};host=$db_host;port=$db_port",$ENV{'MYSQL_USER'},$ENV{'MYSQL_PASSWORD'}) or return 0;
   return $dbh;
 }
 

--- a/lib/inventory.pm
+++ b/lib/inventory.pm
@@ -3,7 +3,7 @@ use Dancer2 ':syntax';
 use Dancer2 ':script';
 use Template;
 use DBI;
-use DBD::mysql;
+use DBD::MariaDB;
 
 set template => 'template_toolkit';
 set layout => undef;
@@ -13,7 +13,7 @@ sub get_connection{
   my $service_name=uc $ENV{'DATABASE_SERVICE_NAME'};
   my $db_host=$ENV{"${service_name}_SERVICE_HOST"};
   my $db_port=$ENV{"${service_name}_SERVICE_PORT"};
-  my $dbh=DBI->connect("DBI:mysql:database=$ENV{'MYSQL_DATABASE'};host=$db_host;port=$db_port",$ENV{'MYSQL_USER'},$ENV{'MYSQL_PASSWORD'}, { RaiseError => 1 } ) or die ("Couldn't connect to database: " . DBI->errstr );
+  my $dbh=DBI->connect("DBI:MariaDB:database=$ENV{'MYSQL_DATABASE'};host=$db_host;port=$db_port",$ENV{'MYSQL_USER'},$ENV{'MYSQL_PASSWORD'}, { RaiseError => 1 } ) or die ("Couldn't connect to database: " . DBI->errstr );
   return $dbh;
 }
 


### PR DESCRIPTION
Switch DBD::mysql to DBD::MariaDB.

Using MariaDB will be used for OpenShift templates as well as separate PR.

See issue https://github.com/sclorg/s2i-perl-container/issues/285

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
